### PR TITLE
Game instance is not verified on blockchaing before joining game#58

### DIFF
--- a/src/pages/games/join.tsx
+++ b/src/pages/games/join.tsx
@@ -4,12 +4,19 @@ import Page from "@/components/Page";
 import { LOCAL_GAME_KEY } from "@/constants";
 import { connectionAtom, gameIdAtom, notificationsAtom } from "@/recoil";
 import { useRouter } from "next/router";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useLocalStorage } from "usehooks-ts";
 import toast from "react-hot-toast";
 import { useFetchGameWalletBalance } from "@/hooks/useFetchGameWalletBalance";
 import { Connection } from "@solana/web3.js";
+import { useMemo } from "react";
+import * as anchor from '@coral-xyz/anchor'
+
+interface onChainGameStatus {
+  verified: boolean
+  valid: boolean
+}
 
 const JoinGamePage = () => {
   const router = useRouter();
@@ -17,24 +24,87 @@ const JoinGamePage = () => {
   const [_, setLocalGameId] = useLocalStorage(LOCAL_GAME_KEY, "");
   const setNotifications = useSetRecoilState(notificationsAtom);
   const [idString, setIdString] = useState("");
+  const [verifyLoading, setVerifyLoading] = useState<boolean>(false);
+  const [onChainGameStatus, setOnChainGameStatus] =
+    useState<onChainGameStatus>({ verified: false, valid: false });
   const rpcRef = useRef<HTMLInputElement>(null);
   const setConnection = useSetRecoilState(connectionAtom);
   const connection = useRecoilValue(connectionAtom);
   const fetchGameWalletBalance = useFetchGameWalletBalance();
 
+  const debounce = (fn: Function, ms: number) => {
+    let timeoutId: ReturnType<typeof setTimeout>;
 
-  const handleEnterGame = useCallback(() => {
+    return function (this: any, ...args: any[]) {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn.apply(this, args), ms);
+    };
+  };
+
+  const verifyGameInstance = useCallback(async (gameId: string) => {
+    let verify = async (gameId: string): Promise<boolean> => {
+      let ret = true;
+
+      try {
+        setVerifyLoading(true);
+        const coreds = new anchor.web3.PublicKey(
+          process.env.NEXT_PUBLIC_COREDS_ID ?? anchor.web3.PublicKey.default
+        );
+        const registry = new anchor.web3.PublicKey(
+          process.env.NEXT_PUBLIC_REGISTRY_ID ?? anchor.web3.PublicKey.default
+        );
+
+        const [registryInstance, _] =
+          anchor.web3.PublicKey.findProgramAddressSync(
+            [
+              anchor.utils.bytes.utf8.encode("registry"),
+              registry.toBuffer(),
+              new anchor.BN(gameId).toArrayLike(Buffer),
+            ],
+            coreds
+          );
+
+        const accountInfo = await connection.getAccountInfo(registryInstance);
+
+        ret =
+          accountInfo != null &&
+          accountInfo.owner.toString() === coreds.toString();
+      } catch (error) {
+        // console.log("[verify] error", error);
+        ret = false;
+      } finally {
+        setVerifyLoading(false);
+      }
+
+      return ret;
+    };
+
+    const isValid = await verify(gameId);
+    setOnChainGameStatus((prevState) => {
+      return { ...prevState, valid: isValid };
+    });
+  }, []);
+
+  const debouncedVerifyGameInstance = useMemo(() => {
+    return debounce(verifyGameInstance, 1000);
+  }, [verifyGameInstance]);
+
+  const handleEnterGame = useCallback(async () => {
     try {
       const gameIdBigInt = BigInt(idString);
       setGameId(gameIdBigInt);
       setLocalGameId(gameIdBigInt.toString());
-      // TODO: [nice to have] Check if game instance is valid on the blockchain
+
+      // By this point, the game instance is validated on the blockchain
       router.push("/fundWallet");
     } catch (error) {
       setNotifications((notifications) => [
         ...notifications,
         { role: "danger", message: "Please enter a valid gameId" },
       ]);
+
+      setOnChainGameStatus({ valid: false, verified: false })
+      setVerifyLoading(false);
       return;
     }
   }, [idString, router, setGameId, setLocalGameId, setNotifications]);
@@ -66,10 +136,39 @@ const JoinGamePage = () => {
           <p className="mr-3 text-2xl">Enter Game ID:</p>
           <TextInput
             value={idString}
-            onChange={(e) => setIdString(e.target.value)}
+            onChange={(e) => {
+              const value = e.target.value;
+              setIdString(value);
+              setOnChainGameStatus((prevState) => {
+                return { ...prevState, verified: true };
+              });
+              if (!verifyLoading) {
+                setVerifyLoading(true);
+              }
+              debouncedVerifyGameInstance(value);
+            }}
           />
         </div>
-        <PrimaryButton className="mt-5" onClick={handleEnterGame}>
+
+        {onChainGameStatus.verified && (
+          <p className="mt-5 text-2xl">
+            {verifyLoading
+              ? "Validating Game..."
+              : onChainGameStatus.valid
+              ? "Game ID is valid!"
+              : "Game ID is not valid!"}
+          </p>
+        )}
+
+        <PrimaryButton
+          className={!onChainGameStatus.verified ? "mt-5" : "mt-2"}
+          onClick={handleEnterGame}
+          disabled={
+            verifyLoading ||
+            !onChainGameStatus.verified ||
+            !onChainGameStatus.valid
+          }
+        >
           Join Game
         </PrimaryButton>
       </div>

--- a/src/pages/games/join.tsx
+++ b/src/pages/games/join.tsx
@@ -12,6 +12,7 @@ import { useFetchGameWalletBalance } from "@/hooks/useFetchGameWalletBalance";
 import { Connection } from "@solana/web3.js";
 import { useMemo } from "react";
 import * as anchor from '@coral-xyz/anchor'
+import { debounce } from "@/utils/debounce";
 
 interface onChainGameStatus {
   verified: boolean
@@ -31,15 +32,6 @@ const JoinGamePage = () => {
   const setConnection = useSetRecoilState(connectionAtom);
   const connection = useRecoilValue(connectionAtom);
   const fetchGameWalletBalance = useFetchGameWalletBalance();
-
-  const debounce = (fn: Function, ms: number) => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    return function (this: any, ...args: any[]) {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => fn.apply(this, args), ms);
-    };
-  };
 
   const verifyGameInstance = useCallback(async (gameId: string) => {
     let verify = async (gameId: string): Promise<boolean> => {

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,8 @@
+export const debounce = (fn: Function, ms: number) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  };
+};


### PR DESCRIPTION
Description:
  Currently, in the /games/join page, the user can press "Join Game"
  even if the game ID does not resolve into a valid registry instance.

Fix:
  Add debounced (1sec) function that tries to compute the registry
  instance PDA and calls RPC to check if that account is a valid one,
  hence the game ID instance is valid.

Testing:
  Input random numers / text into Game ID field and check that verification
    fails -> "Join Game" button stays disabled and status text reflects that
    game is not valid ("Game ID is not valid!").
  Input valid game ID and check that "Join Game" button is enabled and
    status text reflects that game is valid ("Game ID is valid!").